### PR TITLE
Replace array_get with Arr::get for 5.8 support

### DIFF
--- a/src/Favicon.php
+++ b/src/Favicon.php
@@ -2,6 +2,8 @@
 
 namespace BeyondCode\LaravelFavicon;
 
+use Illuminate\Support\Arr;
+
 class Favicon
 {
     /** @var array */
@@ -14,16 +16,16 @@ class Favicon
 
     public function getFaviconText(string $environment)
     {
-        return array_get($this->config, 'enabled_environments.'.$environment.'.text');
+        return Arr::get($this->config, 'enabled_environments.'.$environment.'.text');
     }
 
     public function getFaviconColor(string $environment)
     {
-        return array_get($this->config, 'enabled_environments.'.$environment.'.color');
+        return Arr::get($this->config, 'enabled_environments.'.$environment.'.color');
     }
 
     public function getFaviconBackgroundColor(string $environment)
     {
-        return array_get($this->config, 'enabled_environments.'.$environment.'.background_color');
+        return Arr::get($this->config, 'enabled_environments.'.$environment.'.background_color');
     }
 }


### PR DESCRIPTION
Replaced usage of array_get helper with Arr::get for Laravel 5.8/9 support.  
https://laravel.com/docs/master/upgrade#string-and-array-helpers