### PR TITLE
Add support for Laravel 5.8.* and 6.* and PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,32 @@ language: php
 php:
   - 7.1
   - 7.2
+  - 7.3
 
 env:
+  global:
+    - ILLUMINATE_VERSION=""
+    - TESTBENCH_VERSION=""
+
   matrix:
     - COMPOSER_FLAGS="--prefer-lowest"
     - COMPOSER_FLAGS=""
+    - ILLUMINATE_VERSION="5.7.*" TESTBENCH_VERSION="3.7.*"
+    - ILLUMINATE_VERSION="5.8.*" TESTBENCH_VERSION="3.8.*"
+    - ILLUMINATE_VERSION="6.*" TESTBENCH_VERSION="4.*"
+
+matrix:
+    exclude:
+        - php: 7.1
+          env: ILLUMINATE_VERSION="6.*" TESTBENCH_VERSION="4.*"
 
 before_script:
   - travis_retry composer self-update
+  - if [ "$ILLUMINATE_VERSION" != "" ] && [ "$TESTBENCH_VERSION" != "" ]; then
+      composer require "illuminate/http:${ILLUMINATE_VERSION}" --no-update;
+      composer require "illuminate/support:${ILLUMINATE_VERSION}" --no-update;
+      composer require "orchestra/testbench:${TESTBENCH_VERSION}" --no-update;
+    fi
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction --prefer-source
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": "^7.1",
-        "illuminate/http": "5.6.*|5.7.*",
-        "illuminate/support": "5.6.*|5.7.*",
+        "illuminate/http": "5.6.*|5.7.*|5.8.*|6.*",
+        "illuminate/support": "5.6.*|5.7.*|5.8.*|6.*",
         "intervention/image": "^2.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
-        "orchestra/testbench": "3.7.*"
+        "phpunit/phpunit": "^7.0|^8.0",
+        "orchestra/testbench": "^3.7|^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/FaviconTest.php
+++ b/tests/FaviconTest.php
@@ -10,7 +10,7 @@ class FaviconTest extends \Orchestra\Testbench\TestCase
     /** @var Favicon */
     protected $favicon;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
I added the version numbers for 5.8.* and 6.* and modified the travis.yml file so that all possible combinations of PHP versions and Laravel are tested.

That would also fix #4.