### PR TITLE
Fix for favicon route when app not in web root

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -6,7 +6,7 @@ if (! function_exists('favicon')) {
     function favicon($image)
     {
         if (app(FaviconGenerator::class)->shouldGenerateFavicon(app()->environment())) {
-            return '/'.config('favicon.url_prefix')."/$image";
+            return rtrim(config('app.url'), '/').'/'.config('favicon.url_prefix')."/$image";
         }
 
         return $image;


### PR DESCRIPTION
Hi, I encountered a problem running favicon when the site is not in webroot (ex: http://localhost/mysite/public) -> generated favicon path was pointing outside the site root.